### PR TITLE
adding github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Trigger Meta Repo Update
+
+on:
+  pull_request:
+    branches:
+      - github-action-test  # Instead of main
+    types:
+      - closed
+
+jobs:
+  trigger-meta-repo:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send repository update event
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/hubspotdev/CODE-Hub/actions/workflows/update-meta-repo.yml/dispatches \
+            -d '{
+              "ref": "main",
+              "inputs": {
+                "repo": "'"${{ github.repository }}"'",
+                "commit": "'"${{ github.sha }}"'",
+                "pr_title": "'"${{ github.event.pull_request.title }}"'",
+                "pr_url": "'"${{ github.event.pull_request.html_url }}"'"
+              }
+            }'

--- a/.github/workflows/trigger-submodule-update.yml
+++ b/.github/workflows/trigger-submodule-update.yml
@@ -1,0 +1,27 @@
+name: Trigger Meta Repo Update
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  trigger-meta-repo:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send repository update event
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/hubspotdev/CODE-Hub/dispatches \
+            -d '{
+              "event_type": "update-meta-repo",
+              "client_payload": {
+                "repo": "'"${{ github.repository }}"'",
+                "commit": "'"${{ github.sha }}"'",
+                "pr_title": "'"${{ github.event.pull_request.title }}"'",
+                "pr_url": "'"${{ github.event.pull_request.html_url }}"'"
+              }
+            }'


### PR DESCRIPTION
Description
Adding github action to update the CODE central/meta repo whenever a PR is closed into main. Updated the name for setAccessToken to be more descriptive and gave the two actions it contains (a get and a set) their own distinct functions and error handling. This also includes the changes from the other open PR.

Fixes # (issue)
#77
https://git.hubteam.com/HubSpot/EcoSAPlanning/issues/77

Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
Screenshot 2025-03-31 at 11 58 59 AM
Checklist:
[x ] I have performed a self-review of my code
[ x] I have commented my code, remember, these are resources to help developers identify patterns for HubSpot integrations
[x ] I have made corresponding changes to the documentation
[ x] My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
[ x] New and existing unit tests pass locally with my changes
[ x] Any dependent changes have been merged and published in downstream modules